### PR TITLE
Documentar reuniones semanales

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/preparacion-reunion.md
+++ b/.github/PULL_REQUEST_TEMPLATE/preparacion-reunion.md
@@ -19,5 +19,4 @@ En esta issue se reflejan los puntos a tratar en la próxima reunión semanal
 
 ### Referencias
 
-* [Acta de la reunión anterior](../blob/master/log/2019-06-12.md)
 * [Cómo conducir la reunión](../blob/master/docs/reuniones-semanales.md)

--- a/docs/reuniones-semanales.md
+++ b/docs/reuniones-semanales.md
@@ -1,0 +1,60 @@
+# Reuniones semanales
+
+Semanalmente nos reunimos durante 30 minutos para charlar.
+
+El siguiente es un formato propuesto para que las reuniones sean lo más productivas posibles, pero en último término no existen restricciones sobre su contenido.
+
+## Roles
+
+La primera persona que llegue a la reunión facilita la misma, y la segunda toma notas.
+
+## Durante la reunión
+
+### 1. Chit-chat
+
+La persona facilitadora dejará unos minutos para conversaciones casuales.
+
+### 2. Anuncios
+
+La facilitadora preguntará al resto de participantes si hay anuncios, y dará la palabra. Los participantes intentarán ser breves.
+
+### 3. Discusión
+
+El facilitador le da al botón merge de la [pull-request abierta en el repositorio con la etiqueta `weekly`](https://github.com/remote-ast/about/pulls?q=is%3Aopen+is%3Apr+label%3Aweekly) que contendrá el acta de la reunión anterior y el feedback del resto de miembros de la comunidad.
+
+El facilitador recorrerá los action-items de la semana anterior, que estarán listados en la descripción de la pull-request que acaba de mergear e irá dando la palabra a la persona asignada a cada action item.
+
+La persona que tome notas recoge de forma concisa las intervenciones de los participantes.
+
+Para aquellas cuestiones que no se hayan concluido, el facilitador con ayuda del los participantes decide si hay que seguir trabajando sobre ella la semana que viene o si se da por concluida.
+
+### 4. Intervenciones libres
+
+Una vez abordados los action items de la semana anterior, el facilitador pregunta a los participantes si hay algún tema del que quieran hablar y va cediendo la palabra. 
+
+Generalmente no habrá tiempo durante los 30 minutos de la reunión, por tanto los participantes harán una descripción breve del tema a tratar, y dichos temas se recogen como action items para la semana siguiente.
+
+### Resumen
+
+El facilitador con ayuda del tomador de notas repasa los action items para la próxima semana. 
+
+Un buen action item debe de ser específico y tener una persona asignada, que puede ser la persona que planteó la pregunta, u otra si se estima más oportuno.
+
+### Despedida
+
+Facilitador agradece a todos la presencia y se despide.
+
+## Notas de la reunión.
+
+Un posible formato es:
+
+- Participantes (en orden alfabético de nombre)
+- Anuncios: Sii alguien ha dado algún anuncio o tiene novedades importantes que contar.
+- Intervenciones
+- Action items
+
+## Después de la reunión.
+
+_Si sabes de GitHub, ofrece ayuda al tomador de notas. Si no sabes, hazlo saber en telegram y te ayudaremos!_
+
+El tomador de notas crea una pull-request con las notas de la reunión. La descripción de la pull-request servirá de preparación para la siguiente reunión. Puedes usar el [template de preparación de la reunión de la siguiente semana](../) y rellenar los huecos.


### PR DESCRIPTION
Implementa uno de los action items para esta semana, descrito en #2 :

- @miguelff definir un formato muy poco restrictivo para que las calls sean productivas.

Podéis por favor revisar el contenido y aportar vuestro feedback? ❤️🙏 