### PR TITLE
Acta 2019-06-19 y preparación 2019-06-26

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/preparacion-reunion.md
+++ b/.github/PULL_REQUEST_TEMPLATE/preparacion-reunion.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-En esta issue se reflejan los puntos a tratar en la próxima reunión semanal 
+En esta PR se reflejan los puntos a tratar en la próxima reunión semanal, los cambios incluyen el acta de la última reunión.
 
 ### Puntos a tratar
 

--- a/log/2019-06-19.md
+++ b/log/2019-06-19.md
@@ -1,0 +1,30 @@
+### Reunión semanal 2019-06-12 9:30/10:00
+
+### Anteriormente
+
+* https://github.com/remote-ast/about/issues/2
+
+### Participantes
+
+* Mayus Sierra
+* Miguel Fernández 
+* Alberto Calderón
+* Lorena Díaz
+
+### Intervenciones
+
+Sobre los action items de la reunión anterior:
+
+* Mayus describe la propuesta del workshop: https://docs.google.com/document/d/1lpHaqBUw1QNrpdha5Qnb0chDqSsVQURhcS5XbKLNajc/edit?usp=sharing (Se insta a leer el documento)
+
+* Miguel definió el formato de la reunión.
+
+* Identidad gráfica: Qué pre-requisitos se necesitan? (planteado por @redhairgraphicworks) Ver action item.
+
+
+### Action items (para el siguiente reunión)
+
+* @Miguelff (y otros miembros): dar feedback en el cuestionario
+* @Mayus: Implementar el cuestionario en gforms, y enviarlo para obtener feedback.
+* @Bertocq: Research sobre que otros sectores son incipientes en el trabajo remoto, para sacar unas conclusiones y ver cómo podemos atraer perfiles en esta comunidad.
+* @redhairgraphicworks: Leer el doc, y ver si en el cuestionario hay alguna pregunta que quiera incluir para obtener alguna información más específica.

--- a/log/2019-06-19.md
+++ b/log/2019-06-19.md
@@ -1,4 +1,4 @@
-### Reunión semanal 2019-06-12 9:30/10:00
+### Reunión semanal 2019-06-19 9:30/10:00
 
 ### Anteriormente
 


### PR DESCRIPTION
En esta PR se reflejan los puntos a tratar en la próxima reunión semanal, los cambios incluyen el acta de la última reunión.

### Puntos a tratar

* Mayus para investigar la forma de hacer el workshop remote friendly y poner una fecha. Miguel para ayudarla.
* Miguel definir un formato muy poco restrictivo para que las calls sean productvas.
* Tratar en la siguiente reunión, brainstorming sobre podríamos dar visibilidad (medios de comunicación? Universidades? Empresas?)
* Lorena, seguir dando forma a la propuesta de proyecto de identidad gráfica para tratar despúes del workshop.
* Todos, definir un dia/hora de conexión a las reuniones para no perder el ritmo en el proyecto.
### Referencias

* [Acta de la reunión anterior](../blob/2019-06-19/log/2019-06-19.md)
* [Cómo conducir la reunión](../blob/master/docs/reuniones-semanales.md)
