### PR TITLE
Preparación Reunión 2019-07-03

### DIFF
--- a/log/2019-06-26.md
+++ b/log/2019-06-26.md
@@ -1,0 +1,34 @@
+### Reunión semanal 2019-06-26 9:30/10:00
+
+### Participantes
+
+- Lluis Toyos
+- Lorena
+- Álex 
+- Miguel
+
+### Intervenciones
+
+* Luis Troyos & Lorena: Hacemos un poco de memoria sobre los puntos ya tratados en anteriores reuniones y nos presentamos mutuamente.
+
+* Luis Troyos: Comenta la posibilidad de realizar algún evento en su zona, similar a una mesa redonda para dar visibilidad al proyecto.
+
+* Lorena: Comenta que puede ser muy buena idea, que hay que ir dándole forma y realizar una propuesta.
+
+* Luis Troyos, Lorena & Álex: Hablamos sobre el futuro workshop que se va a realizar y que aún no se había podido revisar la información.
+ Hablamos de la necesidad de ir decidiendo un día concreto para realizarlo.
+(Tema ya aclarado posteriormente a la reunión).
+
+* Miguel: Interviene para saludarnos un rato en la reunión, charlamos distendidamente.
+
+* Luis Troyos, Lorena, Álex & Miguel: Dada la escasa participación en la reunión se habla de realizar la misma en otro día/hora.
+
+
+### Action items (para el siguiente reunión) he dejado los anteriores deberes y añado.
+
+* Mayus para investigar la forma de hacer el workshop remote friendly y poner una fecha. Miguel para ayudarla.
+* Leo y Alberto, preguntar si su mujer y hermano respectivamente quieren acercarse a la comunidad como trabajadores remotos que no pertenezcan al colectivo de programadores o diseñadores, ya que su input podría ser muy interesante.
+* Miguel definir un formato muy poco restrictivo para que las calls sean productvas.
+* Tratar en la siguiente reunión, brainstorming sobre podríamos dar visibilidad (medios de comunicación? Universidades? Empresas?)
+* Lorena, seguir dando forma a la propuesta de proyecto de identidad gráfica para tratar despúes del workshop.
+* Todos, definir un dia/hora de conexión a las reuniones para no perder el ritmo en el proyecto.


### PR DESCRIPTION
En esta PR se reflejan los puntos a tratar en la próxima reunión semanal, los cambios incluyen el acta de la última reunión.

### Puntos a tratar

* Mayus para investigar la forma de hacer el workshop remote friendly y poner una fecha. Miguel para ayudarla.
* Miguel definir un formato muy poco restrictivo para que las calls sean productvas.
* Tratar en la siguiente reunión, brainstorming sobre podríamos dar visibilidad (medios de comunicación? Universidades? Empresas?)
* Lorena, seguir dando forma a la propuesta de proyecto de identidad gráfica para tratar despúes del workshop.
* Todos, definir un dia/hora de conexión a las reuniones para no perder el ritmo en el proyecto.

### Referencias

* [Acta de la reunión anterior](../blob/master/log/2019-06-26.md)
* [Cómo conducir la reunión](../blob/master/docs/reuniones-semanales.md)
